### PR TITLE
DR2-1348 Add S3 copy lambda

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: DR2 Tag and pre deploy
+on:
+  push:
+    branches:
+      - main
+permissions:
+  id-token: write
+  contents: write
+jobs:
+  pre-deploy:
+    uses: nationalarchives/dr2-github-actions/.github/workflows/lambda_build.yml@main
+    with:
+      repo-name: dr2-s3-copy
+      artifact-name: dr2-s3-copy
+      build-command: sbt assembly
+    secrets:
+      MANAGEMENT_ACCOUNT: ${{ secrets.MANAGEMENT_ACCOUNT }}
+      WORKFLOW_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+  deploy:
+    needs: pre-deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: gh workflow run deploy.yml -f environment=intg -f to-deploy=${{ needs.pre-deploy.outputs.next-version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy Dr2 S3 Copy Lambda
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        description: 'Environment'
+        required: true
+        options:
+          - intg
+          - staging
+          - prod
+        default: 'intg'
+      to-deploy:
+        description: 'Version to deploy'
+        required: true
+
+permissions:
+  id-token: write
+  contents: write
+jobs:
+  deploy:
+    uses: nationalarchives/dr2-github-actions/.github/workflows/lambda_deploy.yml@main
+    with:
+      lambda-name: ${{ github.event.inputs.environment }}-s3-copy
+      deployment-package:  dr2-s3-copy.jar
+      environment: ${{ github.event.inputs.environment }}
+      to-deploy: ${{ github.event.inputs.to-deploy }}
+    secrets:
+      ACCOUNT_NUMBER: ${{ secrets.ACCOUNT_NUMBER }}
+      MANAGEMENT_ACCOUNT: ${{ secrets.MANAGEMENT_ACCOUNT }}
+      WORKFLOW_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: DR2 Run Lambda Tests
+on:
+  push:
+    branches-ignore:
+      - main
+      - release-*
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  test:
+    uses: nationalarchives/dr2-github-actions/.github/workflows/dr2_test.yml@main
+    with:
+      repo-name: dr2-s3-copy
+      test-command: sbt scalafmtCheckAll test
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# macOS
+.DS_Store
+
+# sbt specific
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+project/local-plugins.sbt
+.history
+.ensime
+.ensime_cache/
+.sbt-scripted/
+local.sbt
+
+# Bloop
+.bsp
+
+# VS Code
+.vscode/
+
+# Metals
+.bloop/
+.metals/
+metals.sbt
+
+# IDEA
+.idea
+.idea_modules
+/.worksheet/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/softwaremill/scala-pre-commit-hooks
+    rev: v0.3.0
+    default_phase: commit
+    hooks:
+      - id: sbt-scalafmt

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,4 @@
+version = 3.7.3
+preset = default
+runner.dialect = scala213
+maxColumn = 120

--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 The National Archives, UK
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # S3 Copy
 
 Due to the limitations of step functions, we can't do a multipart upload using native step function actions.
-This will cause problems later because the standard copy option can only copy files up to 5Gb so we need this custom lambda to do the copy operation.
+This will cause problems later because the standard copy option can only copy files up to 5GB so we need this custom lambda to do the copy operation.
 
 Currently, we're using static credentials to access the bucket for Preservica. 
-This lambda wil stream the file from our staging cache bucket using its own IAM role. 
+This lambda will stream files from our staging cache bucket using its own IAM role. 
 It will then get the credentials from Systems Manager for the Preservica user which will allow us to stream the file to their bucket.
 
 When we have a role set up which will allow access to the Preservica bucket, this lambda can be changed to use the copy command.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
 # S3 Copy
+
+Due to the limitations of step functions, we can't do a multipart upload using native step function actions.
+This will cause problems later because the standard copy option can only copy files up to 5Gb so we need this custom lambda to do the copy operation.
+
+Currently, we're using static credentials to access the bucket for Preservica. 
+This lambda wil stream the file from our staging cache bucket using its own IAM role. 
+It will then get the credentials from Systems Manager for the Preservica user which will allow us to stream the file to their bucket.
+
+When we have a role set up which will allow access to the Preservica bucket, this lambda can be changed to use the copy command.
+
+[Link to the infrastructure code](https://github.com/nationalarchives/dr2-terraform-environments)
+
+## Environment Variables
+
+| Name        | Description                              |
+|-------------|------------------------------------------|
+| ENVIRONMENT | The environment the lambda is running in |
+
+## Example input
+```json
+{
+  "BatchInput": {
+    "tnaBucket": "<environment>-dr2-ingest-staging-cache",
+    "preservicaBucket": "preservica-bucket"
+  },
+  "Items": [
+    {
+      "Key": "opex/executionId/file",
+      "Size": 1
+    }
+  ]
+}
+```

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,34 @@
+import Dependencies._
+import uk.gov.nationalarchives.sbt.Log4j2MergePlugin.log4j2MergeStrategy
+
+ThisBuild / organization := "uk.gov.nationalarchives"
+ThisBuild / scalaVersion := "2.13.12"
+
+lazy val root = (project in file(".")).
+  settings(
+    name := "dr2-s3-copy",
+    libraryDependencies ++= Seq(
+      circeParser,
+      lambdaCore,
+      log4jCore,
+      log4jSlf4j,
+      log4jTemplateJson,
+      pureConfig,
+      pureConfigCats,
+      s3Client,
+      ssm,
+      mockito % Test,
+      reactorTest % Test,
+      scalaTest % Test
+    ),
+    scalacOptions += "-deprecation"
+  )
+(assembly / assemblyJarName) := "dr2-s3-copy.jar"
+
+scalacOptions ++= Seq("-Wunused:imports", "-Werror")
+
+(assembly / assemblyMergeStrategy) := {
+  case PathList(ps@_*) if ps.last == "Log4j2Plugins.dat" => log4j2MergeStrategy
+  case _ => MergeStrategy.first
+}
+

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,17 @@
+import sbt._
+object Dependencies {
+  lazy val logbackVersion = "2.20.0"
+  lazy val log4jSlf4j = "org.apache.logging.log4j" % "log4j-slf4j-impl" % logbackVersion
+  lazy val log4jCore = "org.apache.logging.log4j" % "log4j-core" % logbackVersion
+  lazy val log4jTemplateJson = "org.apache.logging.log4j" % "log4j-layout-template-json" % logbackVersion
+  lazy val lambdaCore = "com.amazonaws" % "aws-lambda-java-core" % "1.2.2"
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.15"
+  lazy val s3Client = "uk.gov.nationalarchives" %% "da-s3-client" % "0.1.27"
+  lazy val ssm = "software.amazon.awssdk" % "ssm" % "2.20.68"
+  lazy val circeParser = "io.circe" %% "circe-parser" % "0.14.5"
+  lazy val pureConfig = "com.github.pureconfig" %% "pureconfig" % "0.17.4"
+  lazy val pureConfigCats = "com.github.pureconfig" %% "pureconfig-cats-effect" % "0.17.4"
+  lazy val mockito = "org.mockito" %% "mockito-scala" % "1.17.12"
+  lazy val reactorTest = "io.projectreactor" % "reactor-test" % "3.5.4"
+  ,
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.4

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.4
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
+addSbtPlugin("uk.gov.nationalarchives" % "sbt-assembly-log4j2" % "0.0.2")

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,1 @@
+environment=${ENVIRONMENT}

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,0 +1,11 @@
+status = warn
+
+name = DR2LambdaLogConfiguration
+
+appender.console.type = Console
+appender.console.name = consoleLogger
+appender.console.json.type = JsonTemplateLayout
+
+rootLogger.level = info
+
+rootLogger.appenderRef.stdout.ref = consoleLogger

--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -1,0 +1,113 @@
+package uk.gov.nationalarchives
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.implicits.toTraverseOps
+import com.amazonaws.services.lambda.runtime.{Context, RequestStreamHandler}
+import io.circe.parser.decode
+import io.circe.{Decoder, HCursor}
+import pureconfig.ConfigSource
+import pureconfig.module.catseffect.syntax._
+import pureconfig.generic.auto._
+import software.amazon.awssdk.auth.credentials.{
+  AwsBasicCredentials,
+  DefaultCredentialsProvider,
+  StaticCredentialsProvider
+}
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3AsyncClient
+import software.amazon.awssdk.services.ssm.SsmAsyncClient
+import software.amazon.awssdk.services.ssm.model.{GetParameterRequest, GetParameterResponse}
+import software.amazon.awssdk.transfer.s3.model.CompletedUpload
+import uk.gov.nationalarchives.Lambda._
+
+import java.io.{InputStream, OutputStream}
+
+class Lambda extends RequestStreamHandler {
+
+  val tnaS3Client: DAS3Client[IO] = DAS3Client[IO]()
+
+  val ssmClient: SsmAsyncClient = SsmAsyncClient
+    .builder()
+    .credentialsProvider(DefaultCredentialsProvider.create())
+    .httpClient(NettyNioAsyncHttpClient.builder().build())
+    .region(Region.EU_WEST_2)
+    .build()
+
+  val preservicaS3Client: AwsBasicCredentials => DAS3Client[IO] = (awsBasicCredentials: AwsBasicCredentials) => {
+    val preservicaAsyncClient = S3AsyncClient
+      .crtBuilder()
+      .region(Region.EU_WEST_2)
+      .credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials))
+      .targetThroughputInGbps(20.0)
+      .minimumPartSizeInBytes(10 * 1024 * 1024)
+      .build()
+    DAS3Client[IO](preservicaAsyncClient)
+  }
+
+  private def getParameterResponse(environment: String): IO[GetParameterResponse] = {
+    val getParameterRequest = GetParameterRequest
+      .builder()
+      .name(s"/$environment/preservica/bulk1/s3/user")
+      .withDecryption(true)
+      .build()
+    IO.fromCompletableFuture(IO(ssmClient.getParameter(getParameterRequest)))
+  }
+
+  private def getCredentials(getParameterResponse: GetParameterResponse): IO[AwsBasicCredentials] = {
+    val valueAsString = getParameterResponse.parameter().value()
+    IO.fromEither(decode[AwsBasicCredentials](valueAsString))
+  }
+
+  private def processInputObject(
+      inputObject: InputObject,
+      tnaBucket: String,
+      preservicaBucket: String,
+      credentials: AwsBasicCredentials
+  ): IO[CompletedUpload] = for {
+    downloadPublisher <- tnaS3Client.download(tnaBucket, inputObject.key)
+    upload <- preservicaS3Client(credentials).upload(
+      preservicaBucket,
+      inputObject.key,
+      inputObject.size,
+      downloadPublisher
+    )
+  } yield upload
+
+  override def handleRequest(inputStream: InputStream, output: OutputStream, context: Context): Unit = {
+    for {
+      config <- ConfigSource.default.loadF[IO, Config]()
+      input <- IO.fromEither(decode[Input](inputStream.readAllBytes().map(_.toChar).mkString))
+      parameterResponse <- getParameterResponse(config.environment)
+      credentials <- getCredentials(parameterResponse)
+      _ <- input.items
+        .map(item => processInputObject(item, input.tnaBucket, input.preservicaBucket, credentials))
+        .sequence
+    } yield ()
+  }.unsafeRunSync()
+}
+object Lambda {
+  implicit val inputObjectDecoder: Decoder[InputObject] = (c: HCursor) =>
+    for {
+      key <- c.downField("Key").as[String]
+      size <- c.downField("Size").as[Long]
+    } yield InputObject(key, size)
+
+  implicit val inputDecoder: Decoder[Input] = (c: HCursor) =>
+    for {
+      items <- c.downField("Items").as[List[InputObject]]
+      tnaBucket <- c.downField("BatchInput").downField("tnaBucket").as[String]
+      preservicaBucket <- c.downField("BatchInput").downField("preservicaBucket").as[String]
+    } yield Input(tnaBucket, preservicaBucket, items)
+
+  implicit val credentialsDecoder: Decoder[AwsBasicCredentials] = (c: HCursor) =>
+    for {
+      accessKey <- c.downField("awsAccessKeyId").as[String]
+      secretKey <- c.downField("awsSecretAccessKey").as[String]
+    } yield AwsBasicCredentials.create(accessKey, secretKey)
+
+  case class Input(tnaBucket: String, preservicaBucket: String, items: List[InputObject])
+  case class InputObject(key: String, size: Long)
+  private case class Config(environment: String)
+}

--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -67,13 +67,13 @@ class Lambda extends RequestStreamHandler {
       credentials: AwsBasicCredentials
   ): IO[CompletedUpload] = for {
     downloadPublisher <- tnaS3Client.download(tnaBucket, inputObject.key)
-    upload <- preservicaS3Client(credentials).upload(
+    completedUpload <- preservicaS3Client(credentials).upload(
       preservicaBucket,
       inputObject.key,
       inputObject.size,
       downloadPublisher
     )
-  } yield upload
+  } yield completedUpload
 
   override def handleRequest(inputStream: InputStream, output: OutputStream, context: Context): Unit = {
     for {

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,0 +1,1 @@
+environment="test"

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -1,0 +1,96 @@
+package uk.gov.nationalarchives
+
+import cats.effect.IO
+import org.mockito.ArgumentMatchers.any
+import org.mockito.{ArgumentCaptor, MockitoSugar}
+import org.reactivestreams.Publisher
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+import reactor.core.publisher.Flux
+import reactor.test.StepVerifier
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.services.s3.model.PutObjectResponse
+import software.amazon.awssdk.services.ssm.SsmAsyncClient
+import software.amazon.awssdk.services.ssm.model.{GetParameterRequest, GetParameterResponse, Parameter}
+import software.amazon.awssdk.transfer.s3.model.CompletedUpload
+
+import java.io.ByteArrayInputStream
+import java.nio.ByteBuffer
+import java.util.concurrent.CompletableFuture
+
+class LambdaTest extends AnyFlatSpec with MockitoSugar {
+
+  val validJson =
+    """{"BatchInput": {"tnaBucket": "tna-bucket","preservicaBucket": "preservica-bucket"},"Items": [{"Key": "testKey","Size": 1}]}"""
+
+  val uploadCaptor: ArgumentCaptor[Publisher[ByteBuffer]] = ArgumentCaptor.forClass(classOf[Publisher[ByteBuffer]])
+  val tnaS3BucketCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
+  val tnaS3KeyCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
+  val preservicaS3BucketCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
+  val preservicaS3KeyCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
+  val preservicaContentLengthCaptor: ArgumentCaptor[Long] = ArgumentCaptor.forClass(classOf[Long])
+  val getParameterCaptor: ArgumentCaptor[GetParameterRequest] = ArgumentCaptor.forClass(classOf[GetParameterRequest])
+
+  val mockSsmClient: SsmAsyncClient = mock[SsmAsyncClient]
+
+  case class TestLambda() extends Lambda {
+    val mockTnaS3Client: DAS3Client[IO] = mock[DAS3Client[IO]]
+    val mockPreservicaS3Client: DAS3Client[IO] = mock[DAS3Client[IO]]
+
+    override val tnaS3Client: DAS3Client[IO] = mockTnaS3Client
+    override val preservicaS3Client: AwsBasicCredentials => DAS3Client[IO] = _ => mockPreservicaS3Client
+    override val ssmClient: SsmAsyncClient = mockSsmClient
+
+    val downloadResponse: IO[Flux[ByteBuffer]] = IO(Flux.just(ByteBuffer.wrap("test".getBytes())))
+    val uploadResponse: IO[CompletedUpload] = IO(
+      CompletedUpload.builder.response(PutObjectResponse.builder.build).build
+    )
+    val parameterValue: Parameter =
+      Parameter.builder().value("{\"awsAccessKeyId\": \"access\", \"awsSecretAccessKey\": \"secret\"}").build()
+    val getParameterResponse: GetParameterResponse = GetParameterResponse.builder.parameter(parameterValue).build()
+    when(tnaS3Client.download(tnaS3BucketCaptor.capture(), tnaS3KeyCaptor.capture()))
+      .thenReturn(downloadResponse)
+    when(
+      mockPreservicaS3Client.upload(
+        preservicaS3BucketCaptor.capture(),
+        preservicaS3KeyCaptor.capture(),
+        preservicaContentLengthCaptor.capture(),
+        uploadCaptor.capture()
+      )
+    )
+      .thenReturn(uploadResponse)
+    when(mockSsmClient.getParameter(getParameterCaptor.capture()))
+      .thenReturn(CompletableFuture.completedFuture(getParameterResponse))
+  }
+  "handleRequest" should "call the AWS methods with the correct parameters" in {
+    TestLambda().handleRequest(new ByteArrayInputStream(validJson.getBytes()), null, null)
+    tnaS3BucketCaptor.getValue should equal("tna-bucket")
+    tnaS3KeyCaptor.getValue should equal("testKey")
+    preservicaS3BucketCaptor.getValue should equal("preservica-bucket")
+    preservicaS3KeyCaptor.getValue should equal("testKey")
+    preservicaContentLengthCaptor.getValue should equal(1)
+    getParameterCaptor.getValue.name() should equal("/test/preservica/bulk1/s3/user")
+    StepVerifier.create(uploadCaptor.getValue).expectNext(ByteBuffer.wrap("test".getBytes())).expectComplete().verify()
+  }
+
+  "handleRequest" should "return an error if the input json is missing required fields" in {
+    val json = "{}"
+    val ex = intercept[Exception] {
+      TestLambda().handleRequest(new ByteArrayInputStream(json.getBytes()), null, null)
+    }
+    ex.getMessage should equal("DecodingFailure at .Items: Missing required field")
+  }
+
+  "handleRequest" should "return an error if the response from parameter store is in an invalid format" in {
+    val parameterValue: Parameter = Parameter.builder().value("{\"invalid\": \"invalidValue\"}").build()
+    val getParameterResponse: GetParameterResponse = GetParameterResponse.builder.parameter(parameterValue).build()
+    val testLambda = TestLambda()
+    reset(mockSsmClient)
+    when(mockSsmClient.getParameter(any[GetParameterRequest]))
+      .thenReturn(CompletableFuture.completedFuture(getParameterResponse))
+    val ex = intercept[Exception] {
+      testLambda.handleRequest(new ByteArrayInputStream(validJson.getBytes()), null, null)
+    }
+    ex.getMessage should equal("DecodingFailure at .awsAccessKeyId: Missing required field")
+  }
+}

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -62,7 +62,7 @@ class LambdaTest extends AnyFlatSpec with MockitoSugar {
     when(mockSsmClient.getParameter(getParameterCaptor.capture()))
       .thenReturn(CompletableFuture.completedFuture(getParameterResponse))
   }
-  
+
   "handleRequest" should "call the AWS methods with the correct parameters" in {
     TestLambda().handleRequest(new ByteArrayInputStream(validJson.getBytes()), null, null)
     tnaS3BucketCaptor.getValue should equal("tna-bucket")

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -62,6 +62,7 @@ class LambdaTest extends AnyFlatSpec with MockitoSugar {
     when(mockSsmClient.getParameter(getParameterCaptor.capture()))
       .thenReturn(CompletableFuture.completedFuture(getParameterResponse))
   }
+  
   "handleRequest" should "call the AWS methods with the correct parameters" in {
     TestLambda().handleRequest(new ByteArrayInputStream(validJson.getBytes()), null, null)
     tnaS3BucketCaptor.getValue should equal("tna-bucket")


### PR DESCRIPTION
This currently gets the user credentials from SSM to create an S3 client
with access to the preservica S3 bucket.

It then streams from our staging bucket using its own credentials and
streams it directly to preservica using their credentials. It never
touches the disk.

This will be changed once we have a role to do a copy rather than
streaming through the lambda.
